### PR TITLE
Use server-side apply

### DIFF
--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -78,7 +78,7 @@ for SPEC in ${SPECS}; do
         # Only apply CRDs, some projects don't publish CRDs independent but as part of an "install bundle"
         cat ${CRDFILE} \
           | yq2 e 'select(.kind == "CustomResourceDefinition")' - \
-          | kubectl apply -f -
+          | kubectl apply --server-side -f -
 
         kubectl proxy --port=${PROXY_PORT} &
 


### PR DESCRIPTION
Large CRD manifests (looking at you kube-prometheus) can cause an error
like this when applied:

```
The CustomResourceDefinition "prometheuses.monitoring.coreos.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```

This commit modifies `gen.sh` to use server-side apply, which doesn't
have this problem.